### PR TITLE
Simplify ranges[] construction

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ module.exports = function () {
     return function () {};
   }
   var active = document.activeElement;
-  var ranges = Array.apply(Array, {
-    length: selection.rangeCount
-  }).map(function(range, index) {
-    return selection.getRangeAt(index);
-  });
+
+  var ranges = [];
+  for (var i = 0; i < selection.rangeCount; i++) {
+    ranges.push(selection.getRangeAt(i));
+  }
 
   switch (active.tagName.toUpperCase()) { // .toUpperCase handles XHTML
     case 'INPUT':


### PR DESCRIPTION
~~[As covered on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Syntax), the syntax for constructing an Array of arbitrary length involves passing the number, rather than an object with a `length` property.~~

This fixes toggle-selection for use with Phantom.JS and other strict interpreters.
