### PR TITLE
No need to protect against undefined "module" word.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var module = module || {};
 
 module.exports = function () {
   var selection = document.getSelection();


### PR DESCRIPTION
that line causes some issues on other libraries. Also the module pattern doesn't require that protection.
