### PR TITLE
chore: npm Ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+example


### PR DESCRIPTION
Add `.npmignore` to exclude the `example` folder from being published via npm in order to reduce the final package size